### PR TITLE
Remove redundant wait in parent process

### DIFF
--- a/src/parent.c
+++ b/src/parent.c
@@ -79,5 +79,6 @@ void parentProcess(int fd[], char *message, int choice)
 
     close(fd[PARENT_READ]);
     close(fd[PARENT_WRITE]);
-    wait(NULL); // Wait for the child process to terminate
+    // The main function will handle waiting for the child
+    // wait(NULL); // Wait for the child process to terminate
 }


### PR DESCRIPTION
## Summary
- comment out wait in `parentProcess` so main handles child termination

## Testing
- `make clean && make`
- run the program with a simple exit command

------
https://chatgpt.com/codex/tasks/task_b_68438b0216cc8324a885f8755bf226de