### PR TITLE
Improve cleanup and ignores

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 build/
 *.o
+tests/test_menu
+tests/test_operations

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.c | $(OBJDIR)
 	$(CC) $(CFLAGS) -c $< -o $@
 
 clean:
-	rm -f $(OBJDIR)/*.o $(TARGET)
+	rm -f $(OBJDIR)/*.o $(TARGET) tests/test_menu tests/test_operations
 tests/test_operations: tests/test_operations.c src/utilities.c | build
 	$(CC) $(CFLAGS) -o $@ $^
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Ensure your project directory is structured properly with `main.c` and `utilitie
 
 This will compile the source files from the `/src` directory and place the executable in the `/build` directory as defined in the Makefile.
 
+Run `make clean` to remove the compiled objects, test binaries, and the executable when you're done experimenting.
+
 ## 📘 How to Play
 
 After compiling, run the executable to access the terminal menu. You may optionally specify the delay (in seconds) as the first argument:


### PR DESCRIPTION
## Summary
- ignore test executables
- remove test executables in `make clean`
- document how to clean build artifacts

## Testing
- `make test`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_b_6843adcf4bb483248100fbf6fd168125